### PR TITLE
ban erigon 3.00.0 for polygon

### DIFF
--- a/compatible-clients.yaml
+++ b/compatible-clients.yaml
@@ -4,3 +4,8 @@ rules:
       - ethereum
     blacklist:
       - v2.40.0
+  - client: erigon
+    networks:
+      - polygon
+    blacklist:
+      - 3.00.0


### PR DESCRIPTION
erigon 3.00.0 doesn't have totalDifficulty eg here

'[{"method":"eth_getBlockByNumber","params":["0x3bd7d8b", false],"id":1,"jsonrpc":"2.0"}]'