### PR TITLE
Add mezo chain configuration

### DIFF
--- a/chains-meta.yaml
+++ b/chains-meta.yaml
@@ -621,6 +621,13 @@
   explorers:
     - https://explorer.test.mezo.org
 - currency:
+    name: Bitcoin
+    symbol: BTC
+    decimals: 18
+  chain-id: 31612
+  explorers:
+    - https://explorer.mezo.org
+- currency:
     name: ApeCoin
     symbol: APE
     decimals: 18

--- a/chains.yaml
+++ b/chains.yaml
@@ -2349,6 +2349,12 @@ chain-settings:
           syncing: 10
           lagging: 5
       chains:
+        - id: Mainnet
+          priority: 100
+          code: MEZO_MAINNET
+          grpcId: 10122
+          short-names: [mezo-mainnet]
+          chain-id: 0x7b7c
         - id: Testnet
           priority: 1
           code: MEZO_TESTNET


### PR DESCRIPTION
## Description

This PR introduces support for the **Mezo Mainnet** to both `chains-meta.yaml` and `chains.yaml`, ensuring accurate representation of its network configuration and explorer.

### 🆕 Additions
- **`chains-meta.yaml`**
  - Added Mezo Mainnet entry with:
    - `chain-id: 31612`
    - Currency: `Bitcoin (BTC)` with `18` decimals
    - Explorer: [https://explorer.mezo.org](https://explorer.mezo.org)

- **`chains.yaml`**
  - Added Mezo Mainnet to `chain-settings`:
    - `id: Mainnet`
    - `priority: 100`
    - `code: MEZO_MAINNET`
    - `grpcId: 10122`
    - `chain-id: 0x7b7c`
    - `short-names: [mezo-mainnet]`

### 🔗 References
- Official Mezo website: [https://mezo.org](https://mezo.org)
- Mezo Mainnet on [ChainList](https://chainlist.org/chain/31612)
- Mezo Mainnet [explorer](https://explorer.mezo.org)

This change ensures that the Mezo Mainnet is correctly identified and prioritized in chain metadata and becomes accessible via its dedicated explorer.
