### PR TITLE
Add B² Network mainnet

### DIFF
--- a/chains-meta.yaml
+++ b/chains-meta.yaml
@@ -1300,3 +1300,10 @@
   chain-id: 46630
   explorers:
     - https://explorer.testnet.chain.robinhood.com
+- currency:
+    name: Bitcoin
+    symbol: BTC
+    decimals: 18
+  chain-id: 223
+  explorers:
+    - https://explorer.bsquared.network

--- a/chains.yaml
+++ b/chains.yaml
@@ -4012,4 +4012,20 @@ chain-settings:
           short-names: [abcore, abcore-mainnet]
           chain-id: 0x9018
           grpcId: 1157
-       
+    - id: bsquared
+      label: B² Network
+      type: eth
+      settings:
+        options:
+          validate-peers: false
+        expected-block-time: 2s
+        lags:
+          syncing: 40
+          lagging: 20
+      chains:
+        - id: Mainnet
+          priority: 100
+          code: BSQUARED_MAINNET
+          short-names: [bsquared, bsquared-mainnet, b2, b2-mainnet]
+          chain-id: 0xdf
+          grpcId: 1158


### PR DESCRIPTION
## Summary
- Adds B² Network mainnet protocol entry (chain-id 0xdf / 223, grpcId 1158) to chains.yaml.
- Adds matching chains-meta.yaml metadata (BTC, decimals 18, explorer https://explorer.bsquared.network).

B² Network is an OP Stack Bitcoin L2 — uses ethereum-pos connector type, expected block time 2s.

## Companion PRs
- emerald-grpc: https://github.com/drpcorg/emerald-grpc/pull/155
- public: https://github.com/drpcorg/public/pull/218
- dproxy: https://github.com/drpcorg/dproxy/pull/2547
- dshackle: https://github.com/drpcorg/dshackle/pull/826
- nodecore: https://github.com/drpcorg/nodecore/pull/180
- infra: https://github.com/drpcorg/infra/pull/4644

🤖 Generated with [Claude Code](https://claude.com/claude-code)