### PR TITLE
Add BattleChain mainnet (chain-id 626)

### DIFF
--- a/chains-meta.yaml
+++ b/chains-meta.yaml
@@ -1356,3 +1356,10 @@
   chain-id: 7080969
   explorers:
     - https://explorer.humanity.org/testnet
+- currency:
+    name: Ether
+    symbol: ETH
+    decimals: 18
+  chain-id: 626
+  explorers:
+    - https://explorer.battlechain.com

--- a/chains.yaml
+++ b/chains.yaml
@@ -4228,3 +4228,29 @@ chain-settings:
           short-names: [humanity-testnet]
           chain-id: 0x6c0c09
           grpcId: 10202
+    - id: battlechain
+      label: BattleChain
+      type: eth
+      settings:
+        method-spec: "zksync"
+        expected-block-time: 250ms
+        allow-pruning-requirement: true
+        lags:
+          syncing: 70
+          lagging: 50
+        options:
+          validate-peers: false
+      chains:
+        - id: Mainnet
+          priority: 100
+          code: BATTLECHAIN_MAINNET
+          short-names: [battlechain, battlechain-mainnet]
+          chain-id: 0x272
+          grpcId: 1168
+          lower-bounds:
+            tx:
+              block: 1
+              hash: "0x8fbda1d247e887141030e1ef1774dcba268180d114d83c9b1e81fa998f880c7f"
+            receipts:
+              block: 1
+              hash: "0x8fbda1d247e887141030e1ef1774dcba268180d114d83c9b1e81fa998f880c7f"


### PR DESCRIPTION
Adds BattleChain to `chains.yaml` (grpcId 1168) and `chains-meta.yaml` (ETH currency + explorer).

BattleChain is a ZKsync-based Ethereum L2 running matter-labs ZK-stack node software, so `method-spec: "zksync"` is used; `expected-block-time` is 250ms; `lower-bounds` reference block 1. Happy to switch the method-spec to plain `eth` if you'd prefer.