### PR TITLE
flare: set validate-peers: false (Avalanche C-chain has no EVM peer count)

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -3320,6 +3320,8 @@ chain-settings:
       type: eth
       settings:
         expected-block-time: 1.5s
+        options:
+          validate-peers: false
         lags:
           syncing: 40
           lagging: 20


### PR DESCRIPTION
Adds `validate-peers: false` to the `flare` chain settings, matching the existing `avalanche`, `aurora`, and `kite` entries.

Flare runs [go-flare](https://github.com/flare-foundation/go-flare), an Avalanche/coreth-based node. Peering happens at the Avalanche P2P layer, so the C-chain EVM RPC always returns `net_peerCount: 0x0` regardless of how many peers the node actually has. With peer validation enabled, the upstream therefore fails the peer check and is permanently reported as `IMMATURE`, even when the node is fully bootstrapped and synced.

Observed on a healthy Flare mainnet node:

```
POST /ext/info    {"method":"info.peers"}     -> {"result":{"numPeers":"166", ...}}   # real Avalanche peers
POST /ext/bc/C/rpc {"method":"net_peerCount"} -> {"result":"0x0"}                     # EVM peer count is always 0
```

`avalanche` and `kite` (also Avalanche C-chains) already carry `validate-peers: false` for exactly this reason; `flare` was simply missed.

Validated locally with `yamale -s chains.yamale.yaml chains.yaml` → success.