### PR TITLE
aptos: set fork-choice to height

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -3989,6 +3989,7 @@ chain-settings:
       label: Aptos
       type: aptos
       settings:
+        fork-choice: height
         options:
           validate-peers: false
         expected-block-time: 100ms


### PR DESCRIPTION
Aptos head events in nodecore use synthetic, height-encoded block ids — the REST head-poll path exposes no usable parent hash, so hash-based (quorum) fork choice can't work. Set `fork-choice: height` for the Aptos protocol, same as Aztec and Kadena.

Follow-up to drpcorg/public#235; surfaced in the review of drpcorg/nodecore#237 (parent-hash discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)