### PR TITLE
disable log index validation for jovay

### DIFF
--- a/chains.yamale.yaml
+++ b/chains.yamale.yaml
@@ -28,6 +28,8 @@ settings:
   mev-critical: bool(required=False)
   disabled: bool(required=False)
   fork-tolerance: int(required=False)
+  support-finalized-block-tag: bool(required=False)
+  support-safe-block-tag: bool(required=False)
 
 ---
 lags:

--- a/chains.yaml
+++ b/chains.yaml
@@ -4120,6 +4120,7 @@ chain-settings:
         expected-block-time: 3s
         options:
           validate-peers: false
+          disable-log-index-validation: true
         lags:
           syncing: 10
           lagging: 5


### PR DESCRIPTION
Jovay numbers receipt `logIndex` per transaction instead of globally within a block, so the EVM log-index validator permanently marks any jovay upstream as fatal.

Verified against the public RPC — block `0xa35383`, tx `0xb65be0ae831c293944697cf7e309853ddf44e66d18b7cdcf0de066407bd73f4d` (txIndex `0x1`) starts at `logIndex: 0x0` even though the first tx in the block has 5 logs:

```
curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xb65be0ae831c293944697cf7e309853ddf44e66d18b7cdcf0de066407bd73f4d"],"id":1}' https://rpc.jovay.io
```

This is chain-wide client behavior, not a broken node, so disable the validator for jovay — same as zeta-chain.