### PR TITLE
feat: add Stellar chain (mainnet + testnet)

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -4009,6 +4009,29 @@ chain-settings:
           short-names: [aptos-testnet]
           chain-id: 0x2
           grpcId: 10203
+    - id: stellar
+      label: Stellar
+      type: stellar
+      settings:
+        options:
+          validate-peers: false
+        expected-block-time: 5s
+        lags:
+          syncing: 10
+          lagging: 5
+      chains:
+        - id: Mainnet
+          priority: 100
+          code: STELLAR_MAINNET
+          short-names: [stellar, stellar-mainnet]
+          chain-id: "Public Global Stellar Network ; September 2015"
+          grpcId: 1169
+        - id: Testnet
+          priority: 30
+          code: STELLAR_TESTNET
+          short-names: [stellar-testnet]
+          chain-id: "Test SDF Network ; September 2015"
+          grpcId: 10204
     - id: orderly
       label: Orderly
       type: eth


### PR DESCRIPTION
Adds the Stellar protocol entry (`type: stellar`) with mainnet and testnet, ahead of stellar-rpc (Soroban RPC) family support in nodecore.

- `chain-id` holds the canonical network passphrase — the exact string `getNetwork` returns, which upstream validation compares (`Public Global Stellar Network ; September 2015` / `Test SDF Network ; September 2015`, both verified against live stellar-rpc 27.1.1 nodes).
- `grpcId` 1169 / 10204 — next free ids in each range; no emerald ChainRef is planned for now (HTTP RPC only), the ids just satisfy the registry schema.
- `expected-block-time: 5s` (~5-6s ledger close), `validate-peers: false` (stellar-rpc exposes no peer count).