### PR TITLE
Add Mova mainnet

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -3859,6 +3859,12 @@ chain-settings:
           short-names: [mova, mova-mainnet]
           chain-id: 0xf1cc
           grpcId: 1170
+        - id: Testnet
+          priority: 10
+          code: MOVA_TESTNET
+          short-names: [mova-testnet, mova-beta]
+          chain-id: 0x2853
+          grpcId: 10205
     - id: lambda-app
       label: LambdaApp
       type: app

--- a/chains.yaml
+++ b/chains.yaml
@@ -3842,6 +3842,23 @@ chain-settings:
           short-names: [moca-testnet]
           chain-id: 0x366a8
           grpcId: 10188
+    - id: mova
+      label: Mova
+      type: eth
+      settings:
+        expected-block-time: 2s
+        options:
+          validate-peers: false
+        lags:
+          syncing: 20
+          lagging: 10
+      chains:
+        - id: Mainnet
+          priority: 100
+          code: MOVA_MAINNET
+          short-names: [mova, mova-mainnet]
+          chain-id: 0xf1cc
+          grpcId: 1170
     - id: lambda-app
       label: LambdaApp
       type: app


### PR DESCRIPTION
Adds Mova ("The Intelligent Value Layer") - a Cosmos SDK / Tendermint chain with an ethermint EVM module, ~2s block time (measured against the public RPC).

- **Mainnet**: EVM chain id 61900 (0xf1cc), grpcId 1170
- **Testnet** ("Mova Beta"/mars): EVM chain id 10323 (0x2853, verified against mars.rpc.movachain.com), grpcId 10205
- type: eth (EVM JSON-RPC + WS served by the rest-server)
- validate-peers: false - cosmos hybrid, net_peerCount is not meaningful
- grpcIds 1169/10204 are taken by the pending stellar PR