### PR TITLE
tron: disable safe block tag

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -1918,6 +1918,7 @@ chain-settings:
       type: eth
       settings:
         method-spec: "tron"
+        support-safe-block-tag: false
         options:
           validate-peers: false
         expected-block-time: 2s


### PR DESCRIPTION
java-tron's json-rpc has no `safe` tag (`-32602: TAG safe not supported`), and nodecore's block processor doesn't recognize that wording in its self-disable list, so it retries the safe-block poll every ~2s forever and spams ERR logs. Same treatment as viction (#220): `support-safe-block-tag: false`. The `finalized` tag (solidified block) keeps working.