### PR TITLE
add celestia protocol (mainnet + mocha testnet)

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -4412,3 +4412,27 @@ chain-settings:
           short-names: [stellar-testnet]
           chain-id: "Test SDF Network ; September 2015"
           grpcId: 10208
+    - id: celestia
+      label: Celestia
+      type: celestia
+      settings:
+        fork-choice: height
+        options:
+          validate-peers: false
+        expected-block-time: 6s
+        lags:
+          syncing: 10
+          lagging: 5
+      chains:
+        - id: Mainnet
+          priority: 100
+          code: CELESTIA_MAINNET
+          short-names: [celestia, celestia-mainnet]
+          chain-id: celestia
+          grpcId: 1175
+        - id: Mocha
+          priority: 30
+          code: CELESTIA_MOCHA
+          short-names: [celestia-mocha, celestia-testnet]
+          chain-id: mocha-4
+          grpcId: 10209


### PR DESCRIPTION
New `celestia` protocol block — Celestia DA network served via the celestia-node JSON-RPC API (new blockchain type in dproxy/nodecore).

- `chains.yaml`: protocol `celestia`, `type: celestia`, block time 6s, `fork-choice: height`; chains `celestia` (chain-id `celestia`, grpcId 1173) and `celestia-mocha` (chain-id `mocha-4`, grpcId 10208)

chain-ids are CometBFT string ids (same convention as the cosmos chains). No chains-meta entry — non-EVM chains are not listed there.

Companion PRs: https://github.com/drpcorg/dproxy/pull/2829, https://github.com/drpcorg/nodecore/pull/326, https://github.com/drpcorg/emerald-grpc/pull/168
